### PR TITLE
Adding italic option

### DIFF
--- a/iridi/iridi.py
+++ b/iridi/iridi.py
@@ -3,23 +3,23 @@ import math
 from typing import Union, Dict, List
 
 
-def print(string: str, colorArr: Union[Dict[str, int], List[str]], bold: bool = False):
-    preset(colorArr).print(string, bold)
+def print(string: str, colorArr: Union[Dict[str, int], List[str]], bold: bool = False, italic: bool = False):
+    preset(colorArr).print(string, bold, italic)
 
 
-def input(string: str, colorArr: Union[Dict[str, int], List[str]], bold: bool = False) -> str:
-    return preset(colorArr).input(string, bold)
+def input(string: str, colorArr: Union[Dict[str, int], List[str]], bold: bool = False, italic: bool = False) -> str:
+    return preset(colorArr).input(string, bold, italic)
 
 
-def beautify(string: str, colorArr: Union[Dict[str, int], List[str]], bold: bool = False) -> str:
-    return preset(colorArr).beautify(string, bold)
+def beautify(string: str, colorArr: Union[Dict[str, int], List[str]], bold: bool = False, italic: bool = False) -> str:
+    return preset(colorArr).beautify(string, bold, italic)
 
 
 class preset:
     def __init__(self, colorArr):
         self.colorArr = colorArr
 
-    def beautify(self, string: str, bold: bool = False) -> str:
+    def beautify(self, string: str, bold: bool = False, italic: bool = False) -> str:
 
         colorArr = self.colorArr
 
@@ -61,10 +61,12 @@ class preset:
             if (i + 1 == colorStopsCount) and index < length:
                 finalStr += (f"\x1b[38;2;{r};{g};{b}m" + string[index])
 
+        if (italic): return "\x1B[3m" + finalStr + u"\u001b[0m" + "\x1B[23m"
+
         return finalStr + u"\u001b[0m"
 
-    def print(self, string: str, bold: bool = False):
-        builtins.print(self.beautify(string, bold))
+    def print(self, string: str, bold: bool = False, italic: bool = False):
+        builtins.print(self.beautify(string, bold, italic))
 
-    def input(self, string: str, bold: bool = False):
-        return builtins.input(self.beautify(string, bold))
+    def input(self, string: str, bold: bool = False, italic: bool = False):
+        return builtins.input(self.beautify(string, bold, italic))


### PR DESCRIPTION
Nice repo!!

Adding italic option to colored text, so with this:

```py
import iridi

iridi.print("This is a normal message", ["#8A2387", "#E94057", "#F27121"], bold=False, italic=False)
iridi.print("This is a bold message", ["#8A2387", "#E94057", "#F27121"], bold=True, italic=False)
iridi.print("This is an italic message", ["#8A2387", "#E94057", "#F27121"], bold=False, italic=True)
iridi.print("This is a bold and italic message", ["#8A2387", "#E94057", "#F27121"], bold=True, italic=True)
```

you will have:

![image](https://user-images.githubusercontent.com/20236175/135944599-2f6a195c-a89a-453d-8547-298bd580174d.png)
